### PR TITLE
Make catkin install work

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,9 +3,13 @@ project(vision_msgs_visualization)
 
 add_definitions(-std=c++11)
 
-find_package(catkin REQUIRED vision_msgs pluginlib rviz)
+find_package(catkin REQUIRED COMPONENTS pluginlib rviz vision_msgs)
 find_package(Boost REQUIRED system filesystem serialization)
-catkin_package()
+catkin_package(
+  # DEPENDS
+  CATKIN_DEPENDS rviz vision_msgs
+  LIBRARIES ${PROJECT_NAME}
+)
 
 if(${catkin_VERSION} VERSION_GREATER "0.7.0")
   find_package(Qt5Core)
@@ -42,8 +46,12 @@ endif()
 
 
 install(TARGETS ${PROJECT_NAME}
-  DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+)
 install(FILES plugin.xml
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
-install(DIRECTORY mesh
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+install(DIRECTORY src/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+  FILES_MATCHING PATTERN "*.h"
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0.2)
 project(vision_msgs_visualization)
 
 add_definitions(-std=c++11)


### PR DESCRIPTION
The plugin wasn't getting installed properly with a `catkin config --install`, so I removed the attempt to install the now-removed `mesh` directory, made some changes based on `catkin_lint` output, and copied some of the install cmake commands from https://github.com/jsk-ros-pkg/jsk_visualization/blob/master/jsk_rviz_plugins/CMakeLists.txt (so probably not every change here was necessary).

Now when I build it in an install workspace, source install/setup.bash, and run rviz I can see the plugin as an option and view a Detection3DArray just like working out of devel.